### PR TITLE
Add a deprecation banner on every HTML page

### DIFF
--- a/_modules/fatiando.html
+++ b/_modules/fatiando.html
@@ -59,7 +59,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/_modules/fatiando.html
+++ b/_modules/fatiando.html
@@ -59,6 +59,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -238,5 +247,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/_modules/fatiando/datasets.html
+++ b/_modules/fatiando/datasets.html
@@ -59,6 +59,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -318,5 +327,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/_modules/fatiando/datasets.html
+++ b/_modules/fatiando/datasets.html
@@ -59,7 +59,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/_modules/fatiando/geothermal/climsig.html
+++ b/_modules/fatiando/geothermal/climsig.html
@@ -59,7 +59,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/_modules/fatiando/geothermal/climsig.html
+++ b/_modules/fatiando/geothermal/climsig.html
@@ -59,6 +59,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -379,5 +388,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/_modules/fatiando/gravmag/basin2d.html
+++ b/_modules/fatiando/gravmag/basin2d.html
@@ -59,6 +59,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -638,5 +647,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/_modules/fatiando/gravmag/basin2d.html
+++ b/_modules/fatiando/gravmag/basin2d.html
@@ -59,7 +59,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/_modules/fatiando/gravmag/eqlayer.html
+++ b/_modules/fatiando/gravmag/eqlayer.html
@@ -59,7 +59,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/_modules/fatiando/gravmag/eqlayer.html
+++ b/_modules/fatiando/gravmag/eqlayer.html
@@ -59,6 +59,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -618,5 +627,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/_modules/fatiando/gravmag/euler.html
+++ b/_modules/fatiando/gravmag/euler.html
@@ -59,7 +59,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/_modules/fatiando/gravmag/euler.html
+++ b/_modules/fatiando/gravmag/euler.html
@@ -59,6 +59,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -532,5 +541,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/_modules/fatiando/gravmag/harvester.html
+++ b/_modules/fatiando/gravmag/harvester.html
@@ -59,7 +59,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/_modules/fatiando/gravmag/harvester.html
+++ b/_modules/fatiando/gravmag/harvester.html
@@ -59,6 +59,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -1076,5 +1085,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/_modules/fatiando/gravmag/imaging.html
+++ b/_modules/fatiando/gravmag/imaging.html
@@ -59,7 +59,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/_modules/fatiando/gravmag/imaging.html
+++ b/_modules/fatiando/gravmag/imaging.html
@@ -59,6 +59,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -410,5 +419,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/_modules/fatiando/gravmag/interactive.html
+++ b/_modules/fatiando/gravmag/interactive.html
@@ -59,7 +59,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/_modules/fatiando/gravmag/interactive.html
+++ b/_modules/fatiando/gravmag/interactive.html
@@ -59,6 +59,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -801,5 +810,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/_modules/fatiando/gravmag/magdir.html
+++ b/_modules/fatiando/gravmag/magdir.html
@@ -59,6 +59,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -325,5 +334,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/_modules/fatiando/gravmag/magdir.html
+++ b/_modules/fatiando/gravmag/magdir.html
@@ -59,7 +59,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/_modules/fatiando/gravmag/normal_gravity.html
+++ b/_modules/fatiando/gravmag/normal_gravity.html
@@ -59,6 +59,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -466,5 +475,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/_modules/fatiando/gravmag/normal_gravity.html
+++ b/_modules/fatiando/gravmag/normal_gravity.html
@@ -59,7 +59,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/_modules/fatiando/gravmag/polyprism.html
+++ b/_modules/fatiando/gravmag/polyprism.html
@@ -59,7 +59,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/_modules/fatiando/gravmag/polyprism.html
+++ b/_modules/fatiando/gravmag/polyprism.html
@@ -59,6 +59,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -954,5 +963,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/_modules/fatiando/gravmag/prism.html
+++ b/_modules/fatiando/gravmag/prism.html
@@ -59,6 +59,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -1155,5 +1164,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/_modules/fatiando/gravmag/prism.html
+++ b/_modules/fatiando/gravmag/prism.html
@@ -59,7 +59,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/_modules/fatiando/gravmag/sphere.html
+++ b/_modules/fatiando/gravmag/sphere.html
@@ -59,7 +59,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/_modules/fatiando/gravmag/sphere.html
+++ b/_modules/fatiando/gravmag/sphere.html
@@ -59,6 +59,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -991,5 +1000,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/_modules/fatiando/gravmag/talwani.html
+++ b/_modules/fatiando/gravmag/talwani.html
@@ -59,6 +59,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -251,5 +260,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/_modules/fatiando/gravmag/talwani.html
+++ b/_modules/fatiando/gravmag/talwani.html
@@ -59,7 +59,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/_modules/fatiando/gravmag/tensor.html
+++ b/_modules/fatiando/gravmag/tensor.html
@@ -59,7 +59,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/_modules/fatiando/gravmag/tensor.html
+++ b/_modules/fatiando/gravmag/tensor.html
@@ -59,6 +59,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -379,5 +388,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/_modules/fatiando/gravmag/tesseroid.html
+++ b/_modules/fatiando/gravmag/tesseroid.html
@@ -59,7 +59,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/_modules/fatiando/gravmag/tesseroid.html
+++ b/_modules/fatiando/gravmag/tesseroid.html
@@ -59,6 +59,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -965,5 +974,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/_modules/fatiando/gravmag/transform.html
+++ b/_modules/fatiando/gravmag/transform.html
@@ -59,6 +59,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -783,5 +792,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/_modules/fatiando/gravmag/transform.html
+++ b/_modules/fatiando/gravmag/transform.html
@@ -59,7 +59,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/_modules/fatiando/gridder.html
+++ b/_modules/fatiando/gridder.html
@@ -59,6 +59,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -982,5 +991,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/_modules/fatiando/gridder.html
+++ b/_modules/fatiando/gridder.html
@@ -59,7 +59,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/_modules/fatiando/inversion/base.html
+++ b/_modules/fatiando/inversion/base.html
@@ -59,6 +59,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -819,5 +828,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/_modules/fatiando/inversion/base.html
+++ b/_modules/fatiando/inversion/base.html
@@ -59,7 +59,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/_modules/fatiando/inversion/hyper_param.html
+++ b/_modules/fatiando/inversion/hyper_param.html
@@ -59,7 +59,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/_modules/fatiando/inversion/hyper_param.html
+++ b/_modules/fatiando/inversion/hyper_param.html
@@ -59,6 +59,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -567,5 +576,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/_modules/fatiando/inversion/misfit.html
+++ b/_modules/fatiando/inversion/misfit.html
@@ -59,7 +59,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/_modules/fatiando/inversion/misfit.html
+++ b/_modules/fatiando/inversion/misfit.html
@@ -59,6 +59,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -439,5 +448,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/_modules/fatiando/inversion/optimization.html
+++ b/_modules/fatiando/inversion/optimization.html
@@ -59,6 +59,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -716,5 +725,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/_modules/fatiando/inversion/optimization.html
+++ b/_modules/fatiando/inversion/optimization.html
@@ -59,7 +59,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/_modules/fatiando/inversion/regularization.html
+++ b/_modules/fatiando/inversion/regularization.html
@@ -59,6 +59,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -834,5 +843,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/_modules/fatiando/inversion/regularization.html
+++ b/_modules/fatiando/inversion/regularization.html
@@ -59,7 +59,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/_modules/fatiando/mesher.html
+++ b/_modules/fatiando/mesher.html
@@ -59,6 +59,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -1916,5 +1925,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/_modules/fatiando/mesher.html
+++ b/_modules/fatiando/mesher.html
@@ -59,7 +59,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/_modules/fatiando/seismic/conv.html
+++ b/_modules/fatiando/seismic/conv.html
@@ -59,7 +59,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/_modules/fatiando/seismic/conv.html
+++ b/_modules/fatiando/seismic/conv.html
@@ -59,6 +59,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -364,5 +373,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/_modules/fatiando/seismic/epic2d.html
+++ b/_modules/fatiando/seismic/epic2d.html
@@ -59,7 +59,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/_modules/fatiando/seismic/epic2d.html
+++ b/_modules/fatiando/seismic/epic2d.html
@@ -59,6 +59,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -271,5 +280,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/_modules/fatiando/seismic/profile.html
+++ b/_modules/fatiando/seismic/profile.html
@@ -59,7 +59,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/_modules/fatiando/seismic/profile.html
+++ b/_modules/fatiando/seismic/profile.html
@@ -59,6 +59,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -347,5 +356,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/_modules/fatiando/seismic/srtomo.html
+++ b/_modules/fatiando/seismic/srtomo.html
@@ -59,7 +59,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/_modules/fatiando/seismic/srtomo.html
+++ b/_modules/fatiando/seismic/srtomo.html
@@ -59,6 +59,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -291,5 +300,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/_modules/fatiando/seismic/ttime2d.html
+++ b/_modules/fatiando/seismic/ttime2d.html
@@ -59,7 +59,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/_modules/fatiando/seismic/ttime2d.html
+++ b/_modules/fatiando/seismic/ttime2d.html
@@ -59,6 +59,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -338,5 +347,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/_modules/fatiando/seismic/wavefd.html
+++ b/_modules/fatiando/seismic/wavefd.html
@@ -59,6 +59,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -1122,5 +1131,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/_modules/fatiando/seismic/wavefd.html
+++ b/_modules/fatiando/seismic/wavefd.html
@@ -59,7 +59,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/_modules/fatiando/utils.html
+++ b/_modules/fatiando/utils.html
@@ -59,7 +59,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/_modules/fatiando/utils.html
+++ b/_modules/fatiando/utils.html
@@ -59,6 +59,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -974,5 +983,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/_modules/fatiando/vis/mpl.html
+++ b/_modules/fatiando/vis/mpl.html
@@ -59,6 +59,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -1247,5 +1256,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/_modules/fatiando/vis/mpl.html
+++ b/_modules/fatiando/vis/mpl.html
@@ -59,7 +59,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/_modules/fatiando/vis/myv.html
+++ b/_modules/fatiando/vis/myv.html
@@ -59,6 +59,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -1169,5 +1178,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/_modules/fatiando/vis/myv.html
+++ b/_modules/fatiando/vis/myv.html
@@ -59,7 +59,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/_modules/index.html
+++ b/_modules/index.html
@@ -58,7 +58,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/_modules/index.html
+++ b/_modules/index.html
@@ -58,6 +58,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -178,5 +187,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/_static/fixed_banner.js
+++ b/_static/fixed_banner.js
@@ -1,0 +1,18 @@
+// When the user scrolls the page, execute fixBanner
+window.onscroll = function() {fixBanner()};
+
+// Get the banner
+var banner = document.getElementById("deprecationBanner");
+
+// Get the offset position of the navbar
+var threshold = banner.offsetTop;
+
+// Add the navbar-fixed-top class to the banner when you reach its scroll
+// position. Remove it when you leave the scroll position.
+function fixBanner() {
+  if (window.pageYOffset > threshold) {
+    banner.classList.add("navbar-fixed-top");
+  } else {
+    banner.classList.remove("navbar-fixed-top");
+  }
+} 

--- a/_static/style.css
+++ b/_static/style.css
@@ -53,6 +53,12 @@ blockquote {
     color: white;
 }
 
+/* Add padding so the transition is smooth */
+.navbar-fixed-top + .navbar {
+    padding-top: 48px;
+}
+
+/* --------------------------------------------- */
 
 .alert {
     font-size: 12pt;

--- a/_static/style.css
+++ b/_static/style.css
@@ -26,6 +26,34 @@ blockquote {
     color: #6F6F6F;
 }
 
+/* Add custom class for the deprecation message. The banner gets fixed on top when */
+/* scrolling thanks to the fixed_banner.js script. */
+.deprecation-message {
+    background-color: #d62728;
+    color: white;
+    font-weight: 600;
+    text-align: center;
+    margin-bottom: 0;
+    padding: .7em;
+    min-height: 3em;
+    width: 100%;
+}
+
+.deprecation-message a {
+    color: white;
+    text-decoration: underline;
+}
+
+.deprecation-message p {
+    margin: 0;
+}
+
+.deprecation-message code {
+    background-color: #d62728;
+    color: white;
+}
+
+
 .alert {
     font-size: 12pt;
 }

--- a/_static/style.css
+++ b/_static/style.css
@@ -28,7 +28,7 @@ blockquote {
 
 /* Add custom class for the deprecation message. The banner gets fixed on top when */
 /* scrolling thanks to the fixed_banner.js script. */
-.deprecation-message {
+.deprecation-banner {
     background-color: #d62728;
     color: white;
     font-weight: 600;
@@ -39,16 +39,16 @@ blockquote {
     width: 100%;
 }
 
-.deprecation-message a {
+.deprecation-banner a {
     color: white;
     text-decoration: underline;
 }
 
-.deprecation-message p {
+.deprecation-banner p {
     margin: 0;
 }
 
-.deprecation-message code {
+.deprecation-banner code {
     background-color: #d62728;
     color: white;
 }

--- a/api/constants.html
+++ b/api/constants.html
@@ -218,5 +218,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/datasets.html
+++ b/api/datasets.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -261,5 +270,7 @@ file format from <a class="reference external" href="https://gist.github.com/leo
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/datasets.html
+++ b/api/datasets.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/api/fatiando.html
+++ b/api/fatiando.html
@@ -60,6 +60,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -254,5 +263,7 @@ Requires <code class="docutils literal"><span class="pre">pytest-cov</span></cod
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/fatiando.html
+++ b/api/fatiando.html
@@ -60,7 +60,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/api/geothermal.climsig.html
+++ b/api/geothermal.climsig.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -611,5 +620,7 @@ temperature perturbation.</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/geothermal.climsig.html
+++ b/api/geothermal.climsig.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/api/geothermal.html
+++ b/api/geothermal.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -175,5 +184,7 @@ temperature perturbations in the surface.</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/geothermal.html
+++ b/api/geothermal.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/api/gravmag.basin2d.html
+++ b/api/gravmag.basin2d.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -1228,5 +1237,7 @@ are optional data weights.</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/gravmag.basin2d.html
+++ b/api/gravmag.basin2d.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/api/gravmag.eqlayer.html
+++ b/api/gravmag.eqlayer.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -2143,5 +2152,7 @@ are optional data weights.</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/gravmag.eqlayer.html
+++ b/api/gravmag.eqlayer.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/api/gravmag.euler.html
+++ b/api/gravmag.euler.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -1063,5 +1072,7 @@ are optional data weights.</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/gravmag.euler.html
+++ b/api/gravmag.euler.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/api/gravmag.harvester.html
+++ b/api/gravmag.harvester.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/api/gravmag.harvester.html
+++ b/api/gravmag.harvester.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -1048,5 +1057,7 @@ weights to low weights more abrupt.</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/gravmag.html
+++ b/api/gravmag.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -223,5 +232,7 @@ functions.</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/gravmag.html
+++ b/api/gravmag.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/api/gravmag.imaging.html
+++ b/api/gravmag.imaging.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -434,5 +443,7 @@ easy 3D plotting)</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/gravmag.imaging.html
+++ b/api/gravmag.imaging.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/api/gravmag.interactive.html
+++ b/api/gravmag.interactive.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -357,5 +366,7 @@ matter (use <code class="docutils literal"><span class="pre">.pkl</span></code> 
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/gravmag.interactive.html
+++ b/api/gravmag.interactive.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/api/gravmag.magdir.html
+++ b/api/gravmag.magdir.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -505,5 +514,7 @@ are optional data weights.</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/gravmag.magdir.html
+++ b/api/gravmag.magdir.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/api/gravmag.normal_gravity.html
+++ b/api/gravmag.normal_gravity.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -474,5 +483,7 @@ free-air correction.</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/gravmag.normal_gravity.html
+++ b/api/gravmag.normal_gravity.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/api/gravmag.polyprism.html
+++ b/api/gravmag.polyprism.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -955,5 +964,7 @@ sensitivity matrix building.</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/gravmag.polyprism.html
+++ b/api/gravmag.polyprism.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/api/gravmag.prism.html
+++ b/api/gravmag.prism.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -1181,5 +1190,7 @@ sensitivity matrix building.</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/gravmag.prism.html
+++ b/api/gravmag.prism.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/api/gravmag.sphere.html
+++ b/api/gravmag.sphere.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -984,5 +993,7 @@ sensitivity matrix building.</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/gravmag.sphere.html
+++ b/api/gravmag.sphere.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/api/gravmag.talwani.html
+++ b/api/gravmag.talwani.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -229,5 +238,7 @@ of the polygons. Use this, e.g., for sensitivity matrix building.</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/gravmag.talwani.html
+++ b/api/gravmag.talwani.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/api/gravmag.tensor.html
+++ b/api/gravmag.tensor.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -352,5 +361,7 @@ on a set of points. The order of the list should be:
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/gravmag.tensor.html
+++ b/api/gravmag.tensor.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/api/gravmag.tesseroid.html
+++ b/api/gravmag.tesseroid.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -991,5 +1000,7 @@ F41-F48, doi:10.1190/geo2015-0204.1</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/gravmag.tesseroid.html
+++ b/api/gravmag.tesseroid.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/api/gravmag.transform.html
+++ b/api/gravmag.transform.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -811,5 +820,7 @@ Applications, Cambridge University Press.</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/gravmag.transform.html
+++ b/api/gravmag.transform.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/api/gridder.html
+++ b/api/gridder.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -946,5 +955,7 @@ Identical to nps returned by pad_array</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/gridder.html
+++ b/api/gridder.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/api/inversion.base.html
+++ b/api/inversion.base.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -717,5 +726,7 @@ like a geometric object, etc.</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/inversion.base.html
+++ b/api/inversion.base.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/api/inversion.html
+++ b/api/inversion.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -493,5 +502,7 @@ replaced by the new value.</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/inversion.html
+++ b/api/inversion.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/api/inversion.hyper_param.html
+++ b/api/inversion.hyper_param.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -505,5 +514,7 @@ for finding the corner of the L-curve, Applied Numerical Mathematics,
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/inversion.hyper_param.html
+++ b/api/inversion.hyper_param.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/api/inversion.misfit.html
+++ b/api/inversion.misfit.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -499,5 +508,7 @@ are optional data weights.</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/inversion.misfit.html
+++ b/api/inversion.misfit.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/api/inversion.optimization.html
+++ b/api/inversion.optimization.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -760,5 +769,7 @@ is zero, reflecting the initial estimate. Will be empty if
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/inversion.optimization.html
+++ b/api/inversion.optimization.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/api/inversion.regularization.html
+++ b/api/inversion.regularization.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -1111,5 +1120,7 @@ small, positive value.</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/inversion.regularization.html
+++ b/api/inversion.regularization.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/api/mesher.html
+++ b/api/mesher.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -2067,5 +2076,7 @@ is a vector, will compare the norm of the vector to <strong>value</strong>.</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/mesher.html
+++ b/api/mesher.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/api/seismic.conv.html
+++ b/api/seismic.conv.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -355,5 +364,7 @@ and stability:</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/seismic.conv.html
+++ b/api/seismic.conv.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/api/seismic.epic2d.html
+++ b/api/seismic.epic2d.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -502,5 +511,7 @@ are optional data weights.</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/seismic.epic2d.html
+++ b/api/seismic.epic2d.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/api/seismic.html
+++ b/api/seismic.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -186,5 +195,7 @@ wave equation</li>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/seismic.html
+++ b/api/seismic.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/api/seismic.profile.html
+++ b/api/seismic.profile.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -530,5 +539,7 @@ The z-axis is positive downward.</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/seismic.profile.html
+++ b/api/seismic.profile.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/api/seismic.srtomo.html
+++ b/api/seismic.srtomo.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -518,5 +527,7 @@ are optional data weights.</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/seismic.srtomo.html
+++ b/api/seismic.srtomo.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/api/seismic.ttime2d.html
+++ b/api/seismic.ttime2d.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -250,5 +259,7 @@ compatible units with <em>prop</em>)</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/seismic.ttime2d.html
+++ b/api/seismic.ttime2d.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/api/seismic.wavefd.html
+++ b/api/seismic.wavefd.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -1085,5 +1094,7 @@ of Seismograms on Regional and Global Scales, Cambridge University Press.</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/seismic.wavefd.html
+++ b/api/seismic.wavefd.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/api/utils.html
+++ b/api/utils.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -1077,5 +1086,7 @@ magnetization vectors.</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/utils.html
+++ b/api/utils.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/api/vis.html
+++ b/api/vis.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -170,5 +179,7 @@ libraries.</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/vis.html
+++ b/api/vis.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/api/vis.mpl.html
+++ b/api/vis.mpl.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/api/vis.mpl.html
+++ b/api/vis.mpl.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -1280,5 +1289,7 @@ above. If the y-axis of the plot is supposed to be z (depth), then use
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/vis.myv.html
+++ b/api/vis.myv.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -1178,5 +1187,7 @@ others</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/api/vis.myv.html
+++ b/api/vis.myv.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/changelog.html
+++ b/changelog.html
@@ -60,6 +60,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -554,5 +563,7 @@ the polygons by hand.</li>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/changelog.html
+++ b/changelog.html
@@ -60,7 +60,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cite.html
+++ b/cite.html
@@ -60,6 +60,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -203,5 +212,7 @@ However, please also <strong>cite the publication</strong> above.</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cite.html
+++ b/cite.html
@@ -60,7 +60,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/contributors.html
+++ b/contributors.html
@@ -60,6 +60,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -167,5 +176,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/contributors.html
+++ b/contributors.html
@@ -60,7 +60,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook.html
+++ b/cookbook.html
@@ -60,6 +60,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -287,5 +296,7 @@ generating synthetic data, running inversions, and plotting things.</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook.html
+++ b/cookbook.html
@@ -60,7 +60,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/geothermal_climsig_abrupt.html
+++ b/cookbook/geothermal_climsig_abrupt.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -190,5 +199,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/geothermal_climsig_abrupt.html
+++ b/cookbook/geothermal_climsig_abrupt.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/geothermal_climsig_linear.html
+++ b/cookbook/geothermal_climsig_linear.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -190,5 +199,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/geothermal_climsig_linear.html
+++ b/cookbook/geothermal_climsig_linear.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/geothermal_climsig_wrong.html
+++ b/cookbook/geothermal_climsig_wrong.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -190,5 +199,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/geothermal_climsig_wrong.html
+++ b/cookbook/geothermal_climsig_wrong.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/gravmag_2d_polygon_interactive.html
+++ b/cookbook/gravmag_2d_polygon_interactive.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/gravmag_2d_polygon_interactive.html
+++ b/cookbook/gravmag_2d_polygon_interactive.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -167,5 +176,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/gravmag_2d_polygon_picker.html
+++ b/cookbook/gravmag_2d_polygon_picker.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -190,5 +199,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/gravmag_2d_polygon_picker.html
+++ b/cookbook/gravmag_2d_polygon_picker.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/gravmag_basin2d_polygonal.html
+++ b/cookbook/gravmag_basin2d_polygonal.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -201,5 +210,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/gravmag_basin2d_polygonal.html
+++ b/cookbook/gravmag_basin2d_polygonal.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/gravmag_basin2d_trapezoidal.html
+++ b/cookbook/gravmag_basin2d_trapezoidal.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -192,5 +201,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/gravmag_basin2d_trapezoidal.html
+++ b/cookbook/gravmag_basin2d_trapezoidal.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/gravmag_basin2d_triangular.html
+++ b/cookbook/gravmag_basin2d_triangular.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -192,5 +201,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/gravmag_basin2d_triangular.html
+++ b/cookbook/gravmag_basin2d_triangular.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/gravmag_eqlayer_pel_polereduc.html
+++ b/cookbook/gravmag_eqlayer_pel_polereduc.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -227,5 +236,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/gravmag_eqlayer_pel_polereduc.html
+++ b/cookbook/gravmag_eqlayer_pel_polereduc.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/gravmag_eqlayer_pel_upcontinue.html
+++ b/cookbook/gravmag_eqlayer_pel_upcontinue.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -218,5 +227,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/gravmag_eqlayer_pel_upcontinue.html
+++ b/cookbook/gravmag_eqlayer_pel_upcontinue.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/gravmag_eqlayer_polereduc.html
+++ b/cookbook/gravmag_eqlayer_polereduc.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -215,5 +224,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/gravmag_eqlayer_polereduc.html
+++ b/cookbook/gravmag_eqlayer_polereduc.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/gravmag_eqlayer_upcontinue.html
+++ b/cookbook/gravmag_eqlayer_upcontinue.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -212,5 +221,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/gravmag_eqlayer_upcontinue.html
+++ b/cookbook/gravmag_eqlayer_upcontinue.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/gravmag_grav_polyprism.html
+++ b/cookbook/gravmag_grav_polyprism.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -195,5 +204,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/gravmag_grav_polyprism.html
+++ b/cookbook/gravmag_grav_polyprism.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/gravmag_grav_prism.html
+++ b/cookbook/gravmag_grav_prism.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -200,5 +209,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/gravmag_grav_prism.html
+++ b/cookbook/gravmag_grav_prism.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/gravmag_grav_sphere.html
+++ b/cookbook/gravmag_grav_sphere.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -191,5 +200,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/gravmag_grav_sphere.html
+++ b/cookbook/gravmag_grav_sphere.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/gravmag_grav_tesseroid.html
+++ b/cookbook/gravmag_grav_tesseroid.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/gravmag_grav_tesseroid.html
+++ b/cookbook/gravmag_grav_tesseroid.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -228,5 +237,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/gravmag_harvester_grav.html
+++ b/cookbook/gravmag_harvester_grav.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/gravmag_harvester_grav.html
+++ b/cookbook/gravmag_harvester_grav.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -228,5 +237,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/gravmag_harvester_tensor.html
+++ b/cookbook/gravmag_harvester_tensor.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/gravmag_harvester_tensor.html
+++ b/cookbook/gravmag_harvester_tensor.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -251,5 +260,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/gravmag_harvester_weights.html
+++ b/cookbook/gravmag_harvester_weights.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -238,5 +247,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/gravmag_harvester_weights.html
+++ b/cookbook/gravmag_harvester_weights.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/gravmag_imaging_geninv.html
+++ b/cookbook/gravmag_imaging_geninv.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -195,5 +204,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/gravmag_imaging_geninv.html
+++ b/cookbook/gravmag_imaging_geninv.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/gravmag_imaging_migration.html
+++ b/cookbook/gravmag_imaging_migration.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -195,5 +204,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/gravmag_imaging_migration.html
+++ b/cookbook/gravmag_imaging_migration.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/gravmag_imaging_sandwich.html
+++ b/cookbook/gravmag_imaging_sandwich.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -190,5 +199,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/gravmag_imaging_sandwich.html
+++ b/cookbook/gravmag_imaging_sandwich.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/gravmag_mag_polyprism.html
+++ b/cookbook/gravmag_mag_polyprism.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -198,5 +207,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/gravmag_mag_polyprism.html
+++ b/cookbook/gravmag_mag_polyprism.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/gravmag_mag_prism.html
+++ b/cookbook/gravmag_mag_prism.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -198,5 +207,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/gravmag_mag_prism.html
+++ b/cookbook/gravmag_mag_prism.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/gravmag_mag_sphere.html
+++ b/cookbook/gravmag_mag_sphere.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -189,5 +198,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/gravmag_mag_sphere.html
+++ b/cookbook/gravmag_mag_sphere.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/gravmag_magdir_dipolemagdir.html
+++ b/cookbook/gravmag_magdir_dipolemagdir.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -218,5 +227,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/gravmag_magdir_dipolemagdir.html
+++ b/cookbook/gravmag_magdir_dipolemagdir.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/gravmag_normal_gravity.html
+++ b/cookbook/gravmag_normal_gravity.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -205,5 +214,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/gravmag_normal_gravity.html
+++ b/cookbook/gravmag_normal_gravity.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/gravmag_tensor_centerofmass.html
+++ b/cookbook/gravmag_tensor_centerofmass.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -200,5 +209,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/gravmag_tensor_centerofmass.html
+++ b/cookbook/gravmag_tensor_centerofmass.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/gravmag_tensor_centerofmass_expanding_window.html
+++ b/cookbook/gravmag_tensor_centerofmass_expanding_window.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/gravmag_tensor_centerofmass_expanding_window.html
+++ b/cookbook/gravmag_tensor_centerofmass_expanding_window.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -213,5 +222,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/gravmag_tensor_invariants.html
+++ b/cookbook/gravmag_tensor_invariants.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/gravmag_tensor_invariants.html
+++ b/cookbook/gravmag_tensor_invariants.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -193,5 +202,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/gravmag_tensor_polyprism.html
+++ b/cookbook/gravmag_tensor_polyprism.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -204,5 +213,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/gravmag_tensor_polyprism.html
+++ b/cookbook/gravmag_tensor_polyprism.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/gravmag_tensor_prism_noisy.html
+++ b/cookbook/gravmag_tensor_prism_noisy.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/gravmag_tensor_prism_noisy.html
+++ b/cookbook/gravmag_tensor_prism_noisy.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -183,5 +192,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/gravmag_transform_deriv.html
+++ b/cookbook/gravmag_transform_deriv.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/gravmag_transform_deriv.html
+++ b/cookbook/gravmag_transform_deriv.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -228,5 +237,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/gravmag_transform_rtp.html
+++ b/cookbook/gravmag_transform_rtp.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -200,5 +209,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/gravmag_transform_rtp.html
+++ b/cookbook/gravmag_transform_rtp.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/gravmag_transform_tga.html
+++ b/cookbook/gravmag_transform_tga.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -189,5 +198,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/gravmag_transform_tga.html
+++ b/cookbook/gravmag_transform_tga.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/gravmag_transform_upcontinue.html
+++ b/cookbook/gravmag_transform_upcontinue.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -203,5 +212,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/gravmag_transform_upcontinue.html
+++ b/cookbook/gravmag_transform_upcontinue.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/grid_cut.html
+++ b/cookbook/grid_cut.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -181,5 +190,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/grid_cut.html
+++ b/cookbook/grid_cut.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/grid_interpolate.html
+++ b/cookbook/grid_interpolate.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -219,5 +228,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/grid_interpolate.html
+++ b/cookbook/grid_interpolate.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/grid_pad.html
+++ b/cookbook/grid_pad.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -236,5 +245,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/grid_pad.html
+++ b/cookbook/grid_pad.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/grid_profile.html
+++ b/cookbook/grid_profile.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -191,5 +200,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/grid_profile.html
+++ b/cookbook/grid_profile.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/grid_scatter.html
+++ b/cookbook/grid_scatter.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -176,5 +185,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/grid_scatter.html
+++ b/cookbook/grid_scatter.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/grid_surfer.html
+++ b/cookbook/grid_surfer.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -179,5 +188,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/grid_surfer.html
+++ b/cookbook/grid_surfer.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/mesher_pointgrid.html
+++ b/cookbook/mesher_pointgrid.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -204,5 +213,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/mesher_pointgrid.html
+++ b/cookbook/mesher_pointgrid.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/mesher_prismmesh.html
+++ b/cookbook/mesher_prismmesh.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -168,5 +177,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/mesher_prismmesh.html
+++ b/cookbook/mesher_prismmesh.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/mesher_prismmesh_filter.html
+++ b/cookbook/mesher_prismmesh_filter.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/mesher_prismmesh_filter.html
+++ b/cookbook/mesher_prismmesh_filter.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -183,5 +192,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/mesher_prismmesh_topo.html
+++ b/cookbook/mesher_prismmesh_topo.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -180,5 +189,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/mesher_prismmesh_topo.html
+++ b/cookbook/mesher_prismmesh_topo.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/mesher_prismmesh_vardens.html
+++ b/cookbook/mesher_prismmesh_vardens.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -176,5 +185,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/mesher_prismmesh_vardens.html
+++ b/cookbook/mesher_prismmesh_vardens.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/mesher_prismrelief_topo.html
+++ b/cookbook/mesher_prismrelief_topo.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -179,5 +188,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/mesher_prismrelief_topo.html
+++ b/cookbook/mesher_prismrelief_topo.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/mesher_squaremesh_from_image.html
+++ b/cookbook/mesher_squaremesh_from_image.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -177,5 +186,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/mesher_squaremesh_from_image.html
+++ b/cookbook/mesher_squaremesh_from_image.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/mesher_tesseroid.html
+++ b/cookbook/mesher_tesseroid.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -170,5 +179,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/mesher_tesseroid.html
+++ b/cookbook/mesher_tesseroid.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/mesher_tesseroidmesh.html
+++ b/cookbook/mesher_tesseroidmesh.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -171,5 +180,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/mesher_tesseroidmesh.html
+++ b/cookbook/mesher_tesseroidmesh.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/mesher_tesseroidmesh_topo.html
+++ b/cookbook/mesher_tesseroidmesh_topo.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -189,5 +198,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/mesher_tesseroidmesh_topo.html
+++ b/cookbook/mesher_tesseroidmesh_topo.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/seismic_epic2d.html
+++ b/cookbook/seismic_epic2d.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -229,5 +238,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/seismic_epic2d.html
+++ b/cookbook/seismic_epic2d.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/seismic_profile_vertical.html
+++ b/cookbook/seismic_profile_vertical.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/seismic_profile_vertical.html
+++ b/cookbook/seismic_profile_vertical.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -208,5 +217,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/seismic_profile_vertical_smooth.html
+++ b/cookbook/seismic_profile_vertical_smooth.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -203,5 +212,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/seismic_profile_vertical_smooth.html
+++ b/cookbook/seismic_profile_vertical_smooth.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/seismic_srtomo_damped.html
+++ b/cookbook/seismic_srtomo_damped.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -225,5 +234,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/seismic_srtomo_damped.html
+++ b/cookbook/seismic_srtomo_damped.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/seismic_srtomo_sharp.html
+++ b/cookbook/seismic_srtomo_sharp.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -227,5 +236,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/seismic_srtomo_sharp.html
+++ b/cookbook/seismic_srtomo_sharp.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/seismic_srtomo_smooth.html
+++ b/cookbook/seismic_srtomo_smooth.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -222,5 +231,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/seismic_srtomo_smooth.html
+++ b/cookbook/seismic_srtomo_smooth.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/seismic_wavefd_elastic_psv.html
+++ b/cookbook/seismic_wavefd_elastic_psv.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -232,5 +241,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/seismic_wavefd_elastic_psv.html
+++ b/cookbook/seismic_wavefd_elastic_psv.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/seismic_wavefd_elastic_sh.html
+++ b/cookbook/seismic_wavefd_elastic_sh.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -222,5 +231,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/seismic_wavefd_elastic_sh.html
+++ b/cookbook/seismic_wavefd_elastic_sh.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/seismic_wavefd_love_wave.html
+++ b/cookbook/seismic_wavefd_love_wave.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -235,5 +244,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/seismic_wavefd_love_wave.html
+++ b/cookbook/seismic_wavefd_love_wave.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/seismic_wavefd_rayleigh_wave.html
+++ b/cookbook/seismic_wavefd_rayleigh_wave.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -242,5 +251,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/seismic_wavefd_rayleigh_wave.html
+++ b/cookbook/seismic_wavefd_rayleigh_wave.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/seismic_wavefd_scalar.html
+++ b/cookbook/seismic_wavefd_scalar.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -217,5 +226,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/seismic_wavefd_scalar.html
+++ b/cookbook/seismic_wavefd_scalar.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/vis_mpl_basemap.html
+++ b/cookbook/vis_mpl_basemap.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -177,5 +186,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/vis_mpl_basemap.html
+++ b/cookbook/vis_mpl_basemap.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/vis_mpl_basemap2.html
+++ b/cookbook/vis_mpl_basemap2.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -180,5 +189,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/vis_mpl_basemap2.html
+++ b/cookbook/vis_mpl_basemap2.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/vis_mpl_basemap3.html
+++ b/cookbook/vis_mpl_basemap3.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -180,5 +189,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/vis_mpl_basemap3.html
+++ b/cookbook/vis_mpl_basemap3.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/vis_mpl_contour.html
+++ b/cookbook/vis_mpl_contour.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -197,5 +206,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/vis_mpl_contour.html
+++ b/cookbook/vis_mpl_contour.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/vis_mpl_irregular_data.html
+++ b/cookbook/vis_mpl_irregular_data.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -190,5 +199,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/vis_mpl_irregular_data.html
+++ b/cookbook/vis_mpl_irregular_data.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/vis_mpl_seismic.html
+++ b/cookbook/vis_mpl_seismic.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -198,5 +207,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/vis_mpl_seismic.html
+++ b/cookbook/vis_mpl_seismic.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/vis_myv_color.html
+++ b/cookbook/vis_myv_color.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -190,5 +199,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/vis_myv_color.html
+++ b/cookbook/vis_myv_color.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/vis_myv_earth.html
+++ b/cookbook/vis_myv_earth.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/cookbook/vis_myv_earth.html
+++ b/cookbook/vis_myv_earth.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -167,5 +176,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/vis_myv_exaggerate.html
+++ b/cookbook/vis_myv_exaggerate.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -181,5 +190,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/cookbook/vis_myv_exaggerate.html
+++ b/cookbook/vis_myv_exaggerate.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/develop.html
+++ b/develop.html
@@ -60,6 +60,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -593,5 +602,7 @@ or <a class="reference external" href="https://github.com/birocoles/">&#64;biroc
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/develop.html
+++ b/develop.html
@@ -60,7 +60,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/docs.html
+++ b/docs.html
@@ -59,7 +59,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/docs.html
+++ b/docs.html
@@ -59,6 +59,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -224,5 +233,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/gallery/gravmag/eqlayer_mag_transform.html
+++ b/gallery/gravmag/eqlayer_mag_transform.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -256,5 +265,7 @@ usually require more configuration.</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/gallery/gravmag/eqlayer_mag_transform.html
+++ b/gallery/gravmag/eqlayer_mag_transform.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/gallery/gravmag/eqlayer_transform.html
+++ b/gallery/gravmag/eqlayer_transform.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -242,5 +251,7 @@ usually require more configuration.</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/gallery/gravmag/eqlayer_transform.html
+++ b/gallery/gravmag/eqlayer_transform.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/gallery/gravmag/euler_expanding_window.html
+++ b/gallery/gravmag/euler_expanding_window.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -259,5 +268,7 @@ for each anomaly.</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/gallery/gravmag/euler_expanding_window.html
+++ b/gallery/gravmag/euler_expanding_window.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/gallery/gravmag/euler_moving_window.html
+++ b/gallery/gravmag/euler_moving_window.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -264,5 +273,7 @@ approach used in all industry software. This is implemented in
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/gallery/gravmag/euler_moving_window.html
+++ b/gallery/gravmag/euler_moving_window.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/gallery/gravmag/tilt_angle.html
+++ b/gallery/gravmag/tilt_angle.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/gallery/gravmag/tilt_angle.html
+++ b/gallery/gravmag/tilt_angle.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -219,5 +228,7 @@ a dashed line on the tilt map.</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/gallery/gridder/point_scatter.html
+++ b/gallery/gridder/point_scatter.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -255,5 +264,7 @@ using <a class="reference internal" href="../../api/gridder.html#fatiando.gridde
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/gallery/gridder/point_scatter.html
+++ b/gallery/gridder/point_scatter.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/gallery/gridder/regular_grid.html
+++ b/gallery/gridder/regular_grid.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -218,5 +227,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/gallery/gridder/regular_grid.html
+++ b/gallery/gridder/regular_grid.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/gallery/index.html
+++ b/gallery/index.html
@@ -60,6 +60,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -261,5 +270,7 @@ or send us a
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/gallery/index.html
+++ b/gallery/index.html
@@ -60,7 +60,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/gallery/seismic/convolutional_model.html
+++ b/gallery/seismic/convolutional_model.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -211,5 +220,7 @@ model into time.</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/gallery/seismic/convolutional_model.html
+++ b/gallery/seismic/convolutional_model.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/gallery/seismic/srtomo_regularized.html
+++ b/gallery/seismic/srtomo_regularized.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -254,5 +263,7 @@ of regularization to invert a synthetic data-set.</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/gallery/seismic/srtomo_regularized.html
+++ b/gallery/seismic/srtomo_regularized.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/gallery/vis/seismic-wiggle.html
+++ b/gallery/vis/seismic-wiggle.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -192,5 +201,7 @@ Function <a class="reference internal" href="../../api/vis.mpl.html#fatiando.vis
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="../../_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/gallery/vis/seismic-wiggle.html
+++ b/gallery/vis/seismic-wiggle.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/genindex.html
+++ b/genindex.html
@@ -59,7 +59,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/genindex.html
+++ b/genindex.html
@@ -59,6 +59,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -3182,5 +3191,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
 
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/index.html
+++ b/index.html
@@ -60,6 +60,15 @@
 
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
     <div class="container">
@@ -315,5 +324,8 @@ source code behind it.</li>
         </p>
     </div>
 </footer>
+    
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -327,5 +327,7 @@ source code behind it.</li>
     
     <!-- Load script for fixing the deprecation warning at the top when scrolling -->
     <script type="text/javascript" src="_static/fixed_banner.js"></script>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/install.html
+++ b/install.html
@@ -60,6 +60,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -305,5 +314,7 @@ Fatiando better and easier to install.</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/install.html
+++ b/install.html
@@ -60,7 +60,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/license.html
+++ b/license.html
@@ -60,6 +60,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -176,5 +185,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/license.html
+++ b/license.html
@@ -60,7 +60,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/news.html
+++ b/news.html
@@ -60,6 +60,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -184,5 +193,7 @@ Watch a recorded version <a class="reference external" href="http://youtu.be/Ec3
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/news.html
+++ b/news.html
@@ -60,7 +60,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/py-modindex.html
+++ b/py-modindex.html
@@ -61,6 +61,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -359,5 +368,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="_static/fixed_banner.js"></script>
   </body>
 </html>

--- a/py-modindex.html
+++ b/py-modindex.html
@@ -61,7 +61,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/search.html
+++ b/search.html
@@ -66,7 +66,7 @@
   <body role="document">
 
 
-  <div class="deprecation-message" id="deprecationBanner">
+  <div class="deprecation-banner" id="deprecationBanner">
     <div class="container">
     <p>
       The <code>fatiando</code> package has been deprecated. Please check out

--- a/search.html
+++ b/search.html
@@ -66,6 +66,15 @@
   <body role="document">
 
 
+  <div class="deprecation-message" id="deprecationBanner">
+    <div class="container">
+    <p>
+      The <code>fatiando</code> package has been deprecated. Please check out
+      the new tools in the Fatiando a Terra website: 
+      <a href="https://www.fatiando.org">www.fatiando.org</a>
+    </p>
+    </div>
+  </div>
 
 
   <div id="navbar" class="navbar navbar-default navbar-default ">
@@ -172,5 +181,7 @@
         </p>
     </div>
 </footer>
+    <!-- Load script for fixing the deprecation warning at the top when scrolling -->
+    <script type="text/javascript" src="_static/fixed_banner.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Add a red banner warning that the `fatiando` package has been deprecated and
pointing users to the new Fatiando website. The banner gets fixed on top when
scrolling thanks to a small JS script. Inspired on matplotlib's docs:
https://matplotlib.org/1.5.3/