### PR TITLE
Add link to updated installation instructions

### DIFF
--- a/install.html
+++ b/install.html
@@ -145,6 +145,18 @@
         </div>
       </div>
     <div class="col-md-9">
+
+<div class="section">
+  <div class="admonition danger">
+    <p class="first admonition-title">Warning</p>
+    <p class="last">
+      These instructions are old and it's very likely they don't work anymore.
+      Please check out the
+      <a class="reference external" href="https://www.fatiando.org/install#installing-the-legacy-fatiando-package">updated instructions</a>
+      to install the legacy <code>fatiando</code> package.
+    </p>
+  </div>
+</div>
       
   <div class="section" id="installing-fatiando">
 <span id="install"></span><h1>Installing Fatiando<a class="headerlink" href="#installing-fatiando" title="Permalink to this headline">¶</a></h1>

--- a/install.html
+++ b/install.html
@@ -152,7 +152,9 @@
     <p class="last">
       These instructions are old and it's very likely they don't work anymore.
       Please check out the
-      <a class="reference external" href="https://www.fatiando.org/install#installing-the-legacy-fatiando-package">updated instructions</a>
+      <a class="reference external"
+        href="https://www.fatiando.org/install#installing-the-legacy-fatiando-package"
+        style="font-weight: 700">updated instructions</a>
       to install the legacy <code>fatiando</code> package.
     </p>
   </div>


### PR DESCRIPTION
Add a warning in the Install page pointing to the updated installation
instructions for the legacy `fatiando` package.

We should wait until https://github.com/fatiando/website/pull/47 is merged before merging this.